### PR TITLE
Bugfix/79 fix missed source during upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,5 @@ typings/
 # End of https://www.gitignore.io/api/node,linux,visualstudiocode,intellij
 
 .idea
+
+target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix missing PostgreSQL credentials which crashes during upgrading (#79)
   - the original defect was introduced with Redmine v4.2.2-3
 - Fix semantic version bug which crashes during upgrading (#82)
-  - the defect was introduced with Redmine v4.1.0-3 
+  - the defect concerns Redmine versions <= v4.1.0-3
+  - the defect does not concern Redmine versions >= v4.1.1-1
  
 ## [v4.2.3-2] - 2022-01-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix defect which prevents updating bundled Redmine plugins (#78)
+- Fix semantic version bug crashes upgrading from Redmine dogu versions older than4.1.0-3 (#82)
 
 ## [v4.2.3-1] - 2021-12-13
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Fix missing PostgreSQL credentials which crashes during upgrading (#79)
+  - the original defect was introduced with Redmine v4.2.2-3
+- Fix semantic version bug which crashes during upgrading (#82)
+  - the defect was introduced with Redmine v4.1.0-3 
+ 
 ## [v4.2.3-2] - 2022-01-06
 ### Changed
 - Update redmine_cas plugin to version 1.5.1 (#76)
 
 ### Fixed
 - Fix defect which prevents updating bundled Redmine plugins (#78)
-- Fix semantic version bug crashes upgrading from Redmine dogu versions older than4.1.0-3 (#82)
 
 ## [v4.2.3-1] - 2021-12-13
 ### Changed

--- a/resources/post-upgrade.sh
+++ b/resources/post-upgrade.sh
@@ -34,7 +34,7 @@ function run_postupgrade() {
     exit 0
   fi
 
-  if [[ "${FROM_VERSION}" =~ ^v3.*$ || "${FROM_VERSION}" =~ ^[v]*4.((0.5-1)|(1.0-[123]))$ ]]; then
+  if versionXLessOrEqualThanY "${FROM_VERSION}" "4.1.0-3"; then
     # This was added due to issue #42. There can be duplicated settings in the database. This sql statement will remove them.
     DELETE_DUPLICATE_STATEMENT="DELETE FROM settings WHERE id IN (SELECT id FROM settings WHERE NOT id IN (SELECT max(id) FROM settings GROUP BY name HAVING count(*) > 1) AND name IN (SELECT name FROM settings GROUP BY name HAVING count(name) > 1))"
     echo "post-upgrade: Deleting duplicate settings in database..."

--- a/resources/post-upgrade.sh
+++ b/resources/post-upgrade.sh
@@ -25,7 +25,7 @@ function run_postupgrade() {
   FROM_VERSION="${1}"
   TO_VERSION="${2}"
 
-  runUtil
+  fetchDatabaseConnection
 
   echo "Executing Redmine post-upgrade from ${FROM_VERSION} to ${TO_VERSION}"
 

--- a/resources/post-upgrade.sh
+++ b/resources/post-upgrade.sh
@@ -25,6 +25,8 @@ function run_postupgrade() {
   FROM_VERSION="${1}"
   TO_VERSION="${2}"
 
+  runUtil
+
   echo "Executing Redmine post-upgrade from ${FROM_VERSION} to ${TO_VERSION}"
 
   if [ "${FROM_VERSION}" = "${TO_VERSION}" ]; then

--- a/resources/pre-upgrade.sh
+++ b/resources/pre-upgrade.sh
@@ -99,7 +99,6 @@ function versionXLessOrEqualThanY() {
 }
 
 # versionXLessThanY returns true if X is less than Y; otherwise false
-# This code origins from https://stackoverflow.com/a/4024263/12529534
 function versionXLessThanY() {
   if [[ "${1}" == "${2}" ]]; then
     return 1

--- a/resources/pre-upgrade.sh
+++ b/resources/pre-upgrade.sh
@@ -6,6 +6,7 @@ set -o pipefail
 # WORKDIR is a Dockerfile global variable
 REDMINE_WORK_DIR="${WORKDIR}"
 MIGRATION_TMP_DIR="/var/tmp/redmine/plugins/migration4.4.2.1"
+ERROR_SLEEP_IN_S=300
 
 function run_preupgrade() {
   FROM_VERSION="${1}"
@@ -40,9 +41,61 @@ function movePluginsToTempDir() {
 }
 
 # versionXLessOrEqualThanY returns true if X is less than or equal to Y; otherwise false
-# This code origins from https://stackoverflow.com/a/4024263/12529534
 function versionXLessOrEqualThanY() {
-  [[ "${1}" == "$(echo -e "${1}\n${2}" | sort -V | head -n1)" ]]
+  local sourceVersion="${1}"
+  local targetVersion="${2}"
+
+  if [[ "${sourceVersion}" == "${targetVersion}" ]]; then
+    return 0
+  fi
+
+  declare -r semVerRegex='([0-9]+)\.([0-9]+)\.([0-9]+)-([0-9]+)'
+
+   sourceMajor=0
+   sourceMinor=0
+   sourceBugfix=0
+   sourceDogu=0
+   targetMajor=0
+   targetMinor=0
+   targetBugfix=0
+   targetDogu=0
+
+  if [[ ${sourceVersion} =~ ${semVerRegex} ]]; then
+    sourceMajor=${BASH_REMATCH[1]}
+    sourceMinor="${BASH_REMATCH[2]}"
+    sourceBugfix="${BASH_REMATCH[3]}"
+    sourceDogu="${BASH_REMATCH[4]}"
+  else
+    echo "ERROR: source dogu version ${sourceVersion} does not seem to be a semantic version"
+    sleep "${ERROR_SLEEP_IN_S}"
+    exit 1
+  fi
+
+  if [[ ${targetVersion} =~ ${semVerRegex} ]]; then
+    targetMajor=${BASH_REMATCH[1]}
+    targetMinor="${BASH_REMATCH[2]}"
+    targetBugfix="${BASH_REMATCH[3]}"
+    targetDogu="${BASH_REMATCH[4]}"
+  else
+    echo "ERROR: target dogu version ${targetVersion} does not seem to be a semantic version"
+    sleep "${ERROR_SLEEP_IN_S}"
+    exit 1
+  fi
+
+  if [[ $((sourceMajor)) -lt $((targetMajor)) ]] ; then
+    return 0;
+  fi
+  if [[ $((sourceMajor)) -le $((targetMajor)) && $((sourceMinor)) -lt $((targetMinor)) ]] ; then
+    return 0;
+  fi
+  if [[ $((sourceMajor)) -le $((targetMajor)) && $((sourceMinor)) -le $((targetMinor)) && $((sourceBugfix)) -lt $((targetBugfix)) ]] ; then
+    return 0;
+  fi
+  if [[ $((sourceMajor)) -le $((targetMajor)) && $((sourceMinor)) -le $((targetMinor)) && $((sourceBugfix)) -le $((targetBugfix)) && $((sourceDogu)) -lt $((targetDogu)) ]] ; then
+    return 0;
+  fi
+
+  return 1
 }
 
 # versionXLessThanY returns true if X is less than Y; otherwise false

--- a/resources/pre-upgrade.sh
+++ b/resources/pre-upgrade.sh
@@ -6,7 +6,6 @@ set -o pipefail
 # WORKDIR is a Dockerfile global variable
 REDMINE_WORK_DIR="${WORKDIR}"
 MIGRATION_TMP_DIR="/var/tmp/redmine/plugins/migration4.4.2.1"
-ERROR_SLEEP_IN_S=300
 
 function run_preupgrade() {
   FROM_VERSION="${1}"
@@ -67,7 +66,6 @@ function versionXLessOrEqualThanY() {
     sourceDogu="${BASH_REMATCH[4]}"
   else
     echo "ERROR: source dogu version ${sourceVersion} does not seem to be a semantic version"
-    sleep "${ERROR_SLEEP_IN_S}"
     exit 1
   fi
 
@@ -78,7 +76,6 @@ function versionXLessOrEqualThanY() {
     targetDogu="${BASH_REMATCH[4]}"
   else
     echo "ERROR: target dogu version ${targetVersion} does not seem to be a semantic version"
-    sleep "${ERROR_SLEEP_IN_S}"
     exit 1
   fi
 

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -217,6 +217,6 @@ function runMain() {
 
 # make the script only run when executed, not when sourced from bats tests)
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  runUtil
+  fetchDatabaseConnection
   runMain
 fi

--- a/resources/util.sh
+++ b/resources/util.sh
@@ -222,9 +222,9 @@ function wait_for_redmine_to_get_healthy() {
 
 function runUtil() {
   echo "get data for database connection"
-  DATABASE_USER=$(doguctl config -e sa-postgresql/username)
-  DATABASE_USER_PASSWORD=$(doguctl config -e sa-postgresql/password)
-  DATABASE_DB=$(doguctl config -e sa-postgresql/database)
+  DATABASE_USER="$(doguctl config -e sa-postgresql/username)"
+  DATABASE_USER_PASSWORD="$(doguctl config -e sa-postgresql/password)"
+  DATABASE_DB="$(doguctl config -e sa-postgresql/database)"
 }
 
 # make the script only run when executed, not when sourced from bats tests)

--- a/resources/util.sh
+++ b/resources/util.sh
@@ -220,7 +220,7 @@ function wait_for_redmine_to_get_healthy() {
   fi
 }
 
-function runUtil() {
+function fetchDatabaseConnection() {
   echo "get data for database connection"
   DATABASE_USER="$(doguctl config -e sa-postgresql/username)"
   DATABASE_USER_PASSWORD="$(doguctl config -e sa-postgresql/password)"
@@ -229,5 +229,5 @@ function runUtil() {
 
 # make the script only run when executed, not when sourced from bats tests)
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  runUtil
+  fetchDatabaseConnection
 fi

--- a/unitTests/post-upgrade.bats
+++ b/unitTests/post-upgrade.bats
@@ -95,12 +95,7 @@ teardown() {
   mock_set_status "${psql}" 0
   mock_set_status "${rake}" 0
   # overwrite plugin env vars for implicit call of install_plugins
-  export DEFAULT_PLUGIN_DIRECTORY="$(mktemp -d)"
-  aPluginDirectory="$(mktemp -d -p "${DEFAULT_PLUGIN_DIRECTORY}")"
-  aPluginFile="$(mktemp -p "${aPluginDirectory}")"
-  pluginName="$(basename "${aPluginDirectory}")"
-  aPluginFileName="$(basename "${aPluginFile}")"
-  export PLUGIN_DIRECTORY="$(mktemp -d)"
+  overwritePluginDirsWithTmpDirs
 
   run run_postupgrade "4.1.0-3" "4.2.0-1"
 
@@ -121,6 +116,56 @@ teardown() {
   refute isVarExported "DATABASE_DB"
 }
 
+@test "run_postupgrade should delete duplicate database settings during upgrade from source versions [v3.3.2-4 to v4.1.0-3] to target version v4.2.0-1" {
+  source /workspace/resources/post-upgrade.sh
+  sourceVersions=("v3.3.2-4" "v3.4.10-1" "v3.4.10-2" "v3.4.11-1" "v3.4.2-2" "v3.4.2-3" "v3.4.2-4" "v3.4.2-5" "v3.4.2-6" "v3.4.8-1" "v3.4.8-2" "v4.0.5-1" "v4.1.0-1" "v4.1.0-2" "v4.1.0-3")
+
+  for sourceVersion in "${sourceVersions[@]}"; do
+    echo "TEST: run_postupgrade ${sourceVersion}" "4.2.0-1"
+
+    mock_set_status "${doguctl}" 0
+    mock_set_output "${doguctl}" "theUser" 1
+    mock_set_output "${doguctl}" "thePassword" 2
+    mock_set_output "${doguctl}" "theDatabase" 3
+    mock_set_output "${doguctl}" "somethingElse" 4
+    mock_set_status "${psql}" 0
+    mock_set_status "${rake}" 0
+    # overwrite plugin env vars for implicit call of install_plugins
+    overwritePluginDirsWithTmpDirs
+
+    run run_postupgrade "${sourceVersion}" "4.2.0-1"
+
+    assert_success
+    assert_line "post-upgrade: Deleting duplicate settings in database..."
+    assert_line "Redmine post-upgrade done"
+  done
+}
+
+@test "run_postupgrade should not delete duplicate database settings during upgrade from source versions higher than v4.1.0-3" {
+  source /workspace/resources/post-upgrade.sh
+  sourceVersions=("v4.1.1-1" "v4.1.1-2" "v4.2.0-1" "v4.2.0-2" "v4.2.1-1" "v4.2.1-2" "v4.2.1-3" "v4.2.2-1" "v4.2.2-2" "v4.2.2-3" "v4.2.2-4" "v4.2.3-1")
+
+  for sourceVersion in "${sourceVersions[@]}"; do
+    echo "TEST: run_postupgrade ${sourceVersion}" "4.2.3-4"
+
+    mock_set_status "${doguctl}" 0
+    mock_set_output "${doguctl}" "theUser" 1
+    mock_set_output "${doguctl}" "thePassword" 2
+    mock_set_output "${doguctl}" "theDatabase" 3
+    mock_set_output "${doguctl}" "somethingElse" 4
+    mock_set_status "${psql}" 0
+    mock_set_status "${rake}" 0
+    # overwrite plugin env vars for implicit call of install_plugins
+    overwritePluginDirsWithTmpDirs
+
+    run run_postupgrade "${sourceVersion}" "4.2.0-1"
+
+    assert_success
+    refute_line "post-upgrade: Deleting duplicate settings in database..."
+    assert_line "Redmine post-upgrade done"
+  done
+}
+
 @test "isVarExported() return true or false if a variable is exported or not" {
   local localEnvVar=hidden
   export exportEnvVar=HELLO
@@ -130,6 +175,17 @@ teardown() {
 
   run isVarExported "exportEnvVar"
   assert_success
+}
+
+function overwritePluginDirsWithTmpDirs() {
+  export DEFAULT_PLUGIN_DIRECTORY="$(mktemp -d)"
+  aPluginDirectory="$(mktemp -d -p "${DEFAULT_PLUGIN_DIRECTORY}")"
+  aPluginFile="$(mktemp -p "${aPluginDirectory}")"
+  pluginName="$(basename "${aPluginDirectory}")"
+  aPluginFileName="$(basename "${aPluginFile}")"
+  export PLUGIN_DIRECTORY="$(mktemp -d)"
+  export DEPRECATED_PLUGIN_STORE="$(mktemp -d)"
+  export MIGRATION_TMP_DIR="$(mktemp -d)"
 }
 
 function isVarExported() {

--- a/unitTests/post-upgrade.bats
+++ b/unitTests/post-upgrade.bats
@@ -14,14 +14,22 @@ setup() {
   export WORKDIR=/workspace
   doguctl="$(mock_create)"
   export doguctl
-  export PATH="${PATH}:${BATS_TMPDIR}"
   ln -s "${doguctl}" "${BATS_TMPDIR}/doguctl"
+  psql="$(mock_create)"
+  export psql
+  ln -s "${psql}" "${BATS_TMPDIR}/psql"
+  rake="$(mock_create)"
+  export rake
+  ln -s "${rake}" "${BATS_TMPDIR}/rake"
+  export PATH="${PATH}:${BATS_TMPDIR}"
 }
 
 teardown() {
   unset STARTUP_DIR
   unset WORKDIR
   rm "${BATS_TMPDIR}/doguctl"
+  rm "${BATS_TMPDIR}/psql"
+  rm "${BATS_TMPDIR}/rake"
 }
 
 @test "versionXLessOrEqualThanY() was properly sourced from pre-upgrade.sh" {
@@ -70,4 +78,18 @@ teardown() {
   assert_line --partial "Migrating plugins finished successfully"
   assert_dir_exist "${productionPluginDir}"
   assert_file_exist "${productionPluginDir}/${pluginName}/${aPluginFileName}"
+}
+
+@test "run_postupgrade should provide PostgresSQL credentials" {
+  source /workspace/resources/post-upgrade.sh
+
+  mock_set_status "${psql}" 0
+  mock_set_status "${rake}" 0
+
+  run run_postupgrade "4.1.0-3" "4.2.0-1"
+
+  assert_success
+
+
+
 }

--- a/unitTests/post-upgrade.bats
+++ b/unitTests/post-upgrade.bats
@@ -39,24 +39,24 @@ teardown() {
 @test "versionXLessOrEqualThanY() was properly sourced from pre-upgrade.sh" {
   source /workspace/resources/post-upgrade.sh
 
-  run versionXLessOrEqualThanY "1.0.0" "1.0.0"
+  run versionXLessOrEqualThanY "1.0.0-1" "1.0.0-1"
   assert_success
-  run versionXLessOrEqualThanY "1.0.0" "1.1.1-1"
+  run versionXLessOrEqualThanY "1.0.0-0" "1.1.1-1"
   assert_success
-  run versionXLessOrEqualThanY "1.0.0" "0.0.9"
+  run versionXLessOrEqualThanY "1.0.0-1" "0.0.9-1"
   assert_failure
-  run versionXLessOrEqualThanY "1.0.0" "0.9.0"
+  run versionXLessOrEqualThanY "1.0.0-1" "0.9.0-1"
   assert_failure
 }
 
 @test "versionXLessThanY() was properly sourced from pre-upgrade.sh" {
   source /workspace/resources/post-upgrade.sh
 
-  run versionXLessThanY "1.0.0" "1.1.0"
+  run versionXLessThanY "1.0.0-1" "1.1.0-1"
   assert_success
-  run versionXLessThanY "1.0.0" "1.1.1-1"
+  run versionXLessThanY "1.0.0-1" "1.1.1-1"
   assert_success
-  run versionXLessThanY "1.0.0" "1.0.0"
+  run versionXLessThanY "1.0.0-1" "1.0.0-1"
   assert_failure
   run versionXLessThanY "1.2.3-4" "0.1.2-3"
   assert_failure

--- a/unitTests/post-upgrade.bats
+++ b/unitTests/post-upgrade.bats
@@ -116,12 +116,12 @@ teardown() {
   refute isVarExported "DATABASE_DB"
 }
 
-@test "run_postupgrade should delete duplicate database settings during upgrade from source versions [v3.3.2-4 to v4.1.0-3] to target version v4.2.0-1" {
+@test "run_postupgrade should delete duplicate database settings during upgrade from source versions [3.3.2-4 to 4.1.0-3] to target version 4.2.0-1" {
   source /workspace/resources/post-upgrade.sh
-  sourceVersions=("v3.3.2-4" "v3.4.10-1" "v3.4.10-2" "v3.4.11-1" "v3.4.2-2" "v3.4.2-3" "v3.4.2-4" "v3.4.2-5" "v3.4.2-6" "v3.4.8-1" "v3.4.8-2" "v4.0.5-1" "v4.1.0-1" "v4.1.0-2" "v4.1.0-3")
+  sourceVersions=("3.3.2-4" "3.4.10-1" "3.4.10-2" "3.4.11-1" "3.4.2-2" "3.4.2-3" "3.4.2-4" "3.4.2-5" "3.4.2-6" "3.4.8-1" "3.4.8-2" "4.0.5-1" "4.1.0-1" "4.1.0-2" "4.1.0-3")
 
   for sourceVersion in "${sourceVersions[@]}"; do
-    echo "TEST: run_postupgrade ${sourceVersion}" "4.2.0-1"
+    echo "TEST: Running: run_postupgrade ${sourceVersion}" "4.2.0-1"
 
     mock_set_status "${doguctl}" 0
     mock_set_output "${doguctl}" "theUser" 1
@@ -138,12 +138,14 @@ teardown() {
     assert_success
     assert_line "post-upgrade: Deleting duplicate settings in database..."
     assert_line "Redmine post-upgrade done"
+
+    echo "TEST: Success: run_postupgrade ${sourceVersion}" "4.2.0-1"
   done
 }
 
-@test "run_postupgrade should not delete duplicate database settings during upgrade from source versions higher than v4.1.0-3" {
+@test "run_postupgrade should not delete duplicate database settings during upgrade from source versions higher than 4.1.0-3" {
   source /workspace/resources/post-upgrade.sh
-  sourceVersions=("v4.1.1-1" "v4.1.1-2" "v4.2.0-1" "v4.2.0-2" "v4.2.1-1" "v4.2.1-2" "v4.2.1-3" "v4.2.2-1" "v4.2.2-2" "v4.2.2-3" "v4.2.2-4" "v4.2.3-1")
+  sourceVersions=("4.1.1-1" "4.1.1-2" "4.2.0-1" "4.2.0-2" "4.2.1-1" "4.2.1-2" "4.2.1-3" "4.2.2-1" "4.2.2-2" "4.2.2-3" "4.2.2-4" "4.2.3-1")
 
   for sourceVersion in "${sourceVersions[@]}"; do
     echo "TEST: run_postupgrade ${sourceVersion}" "4.2.3-4"
@@ -158,7 +160,7 @@ teardown() {
     # overwrite plugin env vars for implicit call of install_plugins
     overwritePluginDirsWithTmpDirs
 
-    run run_postupgrade "${sourceVersion}" "4.2.0-1"
+    run run_postupgrade "${sourceVersion}" "4.2.3-4"
 
     assert_success
     refute_line "post-upgrade: Deleting duplicate settings in database..."

--- a/unitTests/pre-upgrade.bats
+++ b/unitTests/pre-upgrade.bats
@@ -26,23 +26,7 @@ teardown() {
 
 @test "versionXLessOrEqualThanY() should return true for versions less than or equal to another" {
   source /workspace/resources/pre-upgrade.sh
-
-  run versionXLessOrEqualThanY "1.0.0" "1.0.0"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0" "1.1.0"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0" "1.0.1"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0" "1.1.1"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0" "1.0.0-1"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0" "1.1.0-1"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0" "1.0.1-1"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0" "1.1.1-1"
-  assert_success
+  export ERROR_SLEEP_IN_S=0
 
   run versionXLessOrEqualThanY "1.0.0-1" "1.0.0-1"
   assert_success
@@ -63,31 +47,6 @@ teardown() {
   run versionXLessOrEqualThanY "1.2.3-4" "1.2.3-5"
   assert_success
 
-  run versionXLessOrEqualThanY "1.0.0" "2.0.0"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0" "2.1.0"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0" "2.0.1"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0" "2.1.1"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0" "2.0.0-1"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0" "2.1.0-1"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0" "2.0.1-1"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0" "2.1.1-1"
-  assert_success
-
-  run versionXLessOrEqualThanY "1.0.0-1" "2.0.0"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0-1" "2.1.0"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0-1" "2.0.1"
-  assert_success
-  run versionXLessOrEqualThanY "1.0.0-1" "2.1.1"
-  assert_success
   run versionXLessOrEqualThanY "1.0.0-1" "2.0.0-1"
   assert_success
   run versionXLessOrEqualThanY "1.0.0-1" "2.1.0-1"
@@ -100,27 +59,7 @@ teardown() {
 
 @test "versionXLessOrEqualThanY() should return false for versions greater than another" {
   source /workspace/resources/pre-upgrade.sh
-
-  run versionXLessOrEqualThanY "1.0.0" "0.0.9"
-  assert_failure
-  run versionXLessOrEqualThanY "1.0.0" "0.9.0"
-  assert_failure
-  run versionXLessOrEqualThanY "1.0.0" "0.9.9"
-  assert_failure
-  run versionXLessOrEqualThanY "1.0.0" "0.0.0"
-  assert_failure
-  run versionXLessOrEqualThanY "1.0.0-0" "0.0.0"
-  assert_failure
-  run versionXLessOrEqualThanY "1.0.0-1" "0.0.0"
-  assert_failure
-  run versionXLessOrEqualThanY "1.0.0" "0.0.0-9"
-  assert_failure
-  run versionXLessOrEqualThanY "1.0.0" "0.1.9-9"
-  assert_failure
-  run versionXLessOrEqualThanY "1.0.0" "0.0.9-9"
-  assert_failure
-  run versionXLessOrEqualThanY "1.0.0" "0.1.9-9"
-  assert_failure
+  export ERROR_SLEEP_IN_S=0
 
   run versionXLessOrEqualThanY "0.0.0-10" "0.0.0-9"
   assert_failure
@@ -139,38 +78,13 @@ teardown() {
   run versionXLessOrEqualThanY "1.0.0-1" "0.9.9-9"
   assert_failure
   run versionXLessOrEqualThanY "1.0.0-0" "0.9.9-9"
-
   assert_failure
+
   run versionXLessOrEqualThanY "1.2.3-4" "0.1.2-3"
   assert_failure
   run versionXLessOrEqualThanY "1.2.3-5" "0.1.2-3"
   assert_failure
 
-  run versionXLessOrEqualThanY "2.0.0" "1.0.0"
-  assert_failure
-  run versionXLessOrEqualThanY "2.1.0" "1.0.0"
-  assert_failure
-  run versionXLessOrEqualThanY "2.0.1" "1.0.0"
-  assert_failure
-  run versionXLessOrEqualThanY "2.1.1" "1.0.0"
-  assert_failure
-  run versionXLessOrEqualThanY "2.0.0-1" "1.0.0"
-  assert_failure
-  run versionXLessOrEqualThanY "2.1.0-1" "1.0.0"
-  assert_failure
-  run versionXLessOrEqualThanY "2.0.1-1" "1.0.0"
-  assert_failure
-  run versionXLessOrEqualThanY "2.1.1-1" "1.0.0"
-  assert_failure
-
-  run versionXLessOrEqualThanY "2.0.0" "1.0.0-1"
-  assert_failure
-  run versionXLessOrEqualThanY "2.1.0" "1.0.0-1"
-  assert_failure
-  run versionXLessOrEqualThanY "2.0.1" "1.0.0-1"
-  assert_failure
-  run versionXLessOrEqualThanY "2.1.1" "1.0.0-1"
-  assert_failure
   run versionXLessOrEqualThanY "2.0.0-1" "1.0.0-1"
   assert_failure
   run versionXLessOrEqualThanY "2.1.0-1" "1.0.0-1"
@@ -183,21 +97,7 @@ teardown() {
 
 @test "versionXLessThanY() should return true for versions less than another" {
   source /workspace/resources/pre-upgrade.sh
-
-  run versionXLessThanY "1.0.0" "1.1.0"
-  assert_success
-  run versionXLessThanY "1.0.0" "1.0.1"
-  assert_success
-  run versionXLessThanY "1.0.0" "1.1.1"
-  assert_success
-  run versionXLessThanY "1.0.0" "1.0.0-1"
-  assert_success
-  run versionXLessThanY "1.0.0" "1.1.0-1"
-  assert_success
-  run versionXLessThanY "1.0.0" "1.0.1-1"
-  assert_success
-  run versionXLessThanY "1.0.0" "1.1.1-1"
-  assert_success
+  export ERROR_SLEEP_IN_S=0
 
   run versionXLessThanY "1.0.0-1" "1.0.0-2"
   assert_success
@@ -214,31 +114,6 @@ teardown() {
   run versionXLessThanY "1.2.3-4" "1.2.3-5"
   assert_success
 
-  run versionXLessThanY "1.0.0" "2.0.0"
-  assert_success
-  run versionXLessThanY "1.0.0" "2.1.0"
-  assert_success
-  run versionXLessThanY "1.0.0" "2.0.1"
-  assert_success
-  run versionXLessThanY "1.0.0" "2.1.1"
-  assert_success
-  run versionXLessThanY "1.0.0" "2.0.0-1"
-  assert_success
-  run versionXLessThanY "1.0.0" "2.1.0-1"
-  assert_success
-  run versionXLessThanY "1.0.0" "2.0.1-1"
-  assert_success
-  run versionXLessThanY "1.0.0" "2.1.1-1"
-  assert_success
-
-  run versionXLessThanY "1.0.0-1" "2.0.0"
-  assert_success
-  run versionXLessThanY "1.0.0-1" "2.1.0"
-  assert_success
-  run versionXLessThanY "1.0.0-1" "2.0.1"
-  assert_success
-  run versionXLessThanY "1.0.0-1" "2.1.1"
-  assert_success
   run versionXLessThanY "1.0.0-1" "2.0.0-1"
   assert_success
   run versionXLessThanY "1.0.0-1" "2.1.0-1"
@@ -251,32 +126,8 @@ teardown() {
 
 @test "versionXLessThanY() should return false for versions greater than another" {
   source /workspace/resources/pre-upgrade.sh
+  export ERROR_SLEEP_IN_S=0
 
-  run versionXLessThanY "1.0.0" "1.0.0"
-  assert_failure
-  run versionXLessThanY "1.0.0" "0.0.9"
-  assert_failure
-  run versionXLessThanY "1.0.0" "0.9.0"
-  assert_failure
-  run versionXLessThanY "1.0.0" "0.9.9"
-  assert_failure
-  run versionXLessThanY "1.0.0" "0.0.0"
-  assert_failure
-  run versionXLessThanY "1.0.0-0" "0.0.0"
-  assert_failure
-  run versionXLessThanY "1.0.0-1" "0.0.0"
-  assert_failure
-  run versionXLessThanY "1.0.0" "0.0.0-9"
-  assert_failure
-  run versionXLessThanY "1.0.0" "0.1.9-9"
-  assert_failure
-  run versionXLessThanY "1.0.0" "0.0.9-9"
-  assert_failure
-  run versionXLessThanY "1.0.0" "0.1.9-9"
-  assert_failure
-
-  run versionXLessThanY "1.0.0" "1.0.0"
-  assert_failure
   run versionXLessThanY "1.0.0-1" "1.0.0-1"
   assert_failure
   run versionXLessThanY "0.0.0-10" "0.0.0-9"
@@ -297,37 +148,11 @@ teardown() {
   assert_failure
   run versionXLessThanY "1.0.0-0" "0.9.9-9"
 
-  assert_failure
   run versionXLessThanY "1.2.3-4" "0.1.2-3"
   assert_failure
   run versionXLessThanY "1.2.3-5" "0.1.2-3"
   assert_failure
 
-  run versionXLessThanY "2.0.0" "1.0.0"
-  assert_failure
-  run versionXLessThanY "2.1.0" "1.0.0"
-  assert_failure
-  run versionXLessThanY "2.0.1" "1.0.0"
-  assert_failure
-  run versionXLessThanY "2.1.1" "1.0.0"
-  assert_failure
-  run versionXLessThanY "2.0.0-1" "1.0.0"
-  assert_failure
-  run versionXLessThanY "2.1.0-1" "1.0.0"
-  assert_failure
-  run versionXLessThanY "2.0.1-1" "1.0.0"
-  assert_failure
-  run versionXLessThanY "2.1.1-1" "1.0.0"
-  assert_failure
-
-  run versionXLessThanY "2.0.0" "1.0.0-1"
-  assert_failure
-  run versionXLessThanY "2.1.0" "1.0.0-1"
-  assert_failure
-  run versionXLessThanY "2.0.1" "1.0.0-1"
-  assert_failure
-  run versionXLessThanY "2.1.1" "1.0.0-1"
-  assert_failure
   run versionXLessThanY "2.0.0-1" "1.0.0-1"
   assert_failure
   run versionXLessThanY "2.1.0-1" "1.0.0-1"

--- a/unitTests/pre-upgrade.bats
+++ b/unitTests/pre-upgrade.bats
@@ -26,7 +26,6 @@ teardown() {
 
 @test "versionXLessOrEqualThanY() should return true for versions less than or equal to another" {
   source /workspace/resources/pre-upgrade.sh
-  export ERROR_SLEEP_IN_S=0
 
   run versionXLessOrEqualThanY "1.0.0-1" "1.0.0-1"
   assert_success
@@ -59,7 +58,6 @@ teardown() {
 
 @test "versionXLessOrEqualThanY() should return false for versions greater than another" {
   source /workspace/resources/pre-upgrade.sh
-  export ERROR_SLEEP_IN_S=0
 
   run versionXLessOrEqualThanY "0.0.0-10" "0.0.0-9"
   assert_failure
@@ -97,7 +95,6 @@ teardown() {
 
 @test "versionXLessThanY() should return true for versions less than another" {
   source /workspace/resources/pre-upgrade.sh
-  export ERROR_SLEEP_IN_S=0
 
   run versionXLessThanY "1.0.0-1" "1.0.0-2"
   assert_success
@@ -126,7 +123,6 @@ teardown() {
 
 @test "versionXLessThanY() should return false for versions greater than another" {
   source /workspace/resources/pre-upgrade.sh
-  export ERROR_SLEEP_IN_S=0
 
   run versionXLessThanY "1.0.0-1" "1.0.0-1"
   assert_failure

--- a/unitTests/startup.bats
+++ b/unitTests/startup.bats
@@ -63,20 +63,6 @@ teardown() {
   assert_line --partial "is not a directory"
 }
 
-@test "install_plugin() should print an log line if a bundled plugin is already installed" {
-  source /workspace/resources/startup.sh
-  export DEFAULT_PLUGIN_DIRECTORY="$(mktemp -d)"
-  aPluginDirectory="$(mktemp -d -p ${DEFAULT_PLUGIN_DIRECTORY})"
-  pluginName="$(basename "${aPluginDirectory}")"
-  export PLUGIN_DIRECTORY="$(mktemp -d)"
-  mkdir -p "${PLUGIN_DIRECTORY}/${pluginName}"
-
-  run install_plugin "${pluginName}"
-
-  assert_success
-  assert_line --partial "already exists. Skip restoring the plugin"
-}
-
 @test "install_plugin() should install a bundled plugin that is absent" {
   source /workspace/resources/startup.sh
   export DEFAULT_PLUGIN_DIRECTORY="$(mktemp -d)"
@@ -89,7 +75,8 @@ teardown() {
   run install_plugin "${pluginName}"
 
   assert_success
-  assert_line "install plugin ${pluginName}"
+  assert_line "deinstall bundled plugin ${pluginName}"
+  assert_line "install bundled plugin ${pluginName}"
   assert_dir_exist "${PLUGIN_DIRECTORY}/${pluginName}"
   assert_file_exist "${PLUGIN_DIRECTORY}/${pluginName}/${aPluginFileName}"
 }
@@ -111,7 +98,8 @@ teardown() {
 
   assert_success
   assert_line "installing plugins..."
-  assert_line "install plugin ${pluginName}"
+  assert_line "deinstall bundled plugin ${pluginName}"
+  assert_line "install bundled plugin ${pluginName}"
   assert_line "running plugin migrations..."
   assert_line "plugin migrations... done"
   assert_dir_exist "${PLUGIN_DIRECTORY}/${pluginName}"


### PR DESCRIPTION
This PR resolves #79 and fixes missing SQL credentials.

Furthermore, this PR replaces an overly complex version check regex with a easier-to-understand method within the post-upgrade script. A proper upgrade from Redmine v3.x to v4.x could not be checked though because v3.x does not even install properly in my development machine :frowning: 

This PR also resolves #82 and replaces a modern bash semver comparison with one that is more compatible with older Redmine dogu versions.