### PR TITLE
#86 fix post upgrade script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Upgrade from dogu version above 4.2.2-1 failed if no additional plugins were installed (#86)
 
 ## [v4.2.3-5] - 2022-02-01
 ### Added

--- a/resources/post-upgrade.sh
+++ b/resources/post-upgrade.sh
@@ -95,11 +95,13 @@ function restorePluginsFromTmpDir(){
   echo "create new redmine plugin directory"
   mkdir "${REDMINE_WORK_DIR:?}/plugins"
 
-  # copy plugins to plugin installation source directory
-  cp -r "${source_directory:?}"/* "${PLUGIN_STORE}"
-  # copy plugins back to redmine plugins directory
-  cp -r "${source_directory:?}"/* "${REDMINE_WORK_DIR}/plugins/"
-
+  # do not try to copy plugins if the source directory is empty
+  if [ "$(ls -A "${source_directory:?}")" ]; then
+    # copy plugins to plugin installation source directory
+    cp -r "${source_directory:?}"/* "${PLUGIN_STORE}"
+    # copy plugins back to redmine plugins directory
+    cp -r "${source_directory:?}"/* "${REDMINE_WORK_DIR}/plugins/"
+  fi
   rm -rf "${source_directory}"
 }
 


### PR DESCRIPTION
do not try to copy plugins back to Redmines plugin directory if the migration
source directory is empty

Resolves #86 