### PR TITLE
#96 Upgrade to base image 3.15.3-1 and fix zlib CVE-2018-25032

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
-- Upgrade base image to 3.15.3-1 #96
-
 ### Fixed
-- Fix zlib CVE-2018-25032 by upgrading version from recent Alpine #96
+- Fix zlib CVE-2018-25032 by upgrading to version 1.2.12-r0 from Alpine 3.14 #96
 
 ## [v4.2.3-9] - 2022-03-11
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Upgrade base image to 3.15.3-1 #96
+
+### Fixed
+- Fix zlib CVE-2018-25032 by upgrading version from recent Alpine #96
 
 ## [v4.2.3-9] - 2022-03-11
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # registry.cloudogu.com/official/redmine
-FROM registry.cloudogu.com/official/base:3.14.3-1
+FROM registry.cloudogu.com/official/base:3.15.3-1
 
 LABEL NAME="official/redmine" \
    VERSION="4.2.3-9" \
@@ -32,6 +32,8 @@ ENV REDMINE_VERSION=4.2.3 \
 COPY resources/ /
 
 RUN set -eux -o pipefail \
+ && apk update \
+ && apk upgrade \
  # add user and group
  && addgroup -S "${USER}" -g 1000 \
  && adduser -S -h "${WORKDIR}" -G "${USER}" -u 1000 -s /bin/bash "${USER}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # registry.cloudogu.com/official/redmine
-FROM registry.cloudogu.com/official/base:3.15.3-1
+FROM registry.cloudogu.com/official/base:3.14.3-1
 
 LABEL NAME="official/redmine" \
    VERSION="4.2.3-9" \


### PR DESCRIPTION
Fixes #96: Upgrade to base image 3.15.3-1 and fix zlib CVE-2018-25032