### PR TITLE
Add gem `bigdecimal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#123] Add gem `bigdecimal` because some plugins like `helpdesk` need the dependency on `bundle install` if redmine is starting up.
 
 ## [v5.0.5-2] - 2023-10-20
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,6 +132,7 @@ RUN set -eux -o pipefail \
  && bundle config set --local without 'development test' \
  && bundle install \
  && gem install puma \
+ && gem install bigdecimal \
  # cleanup
  && gem cleanup all \
  && rm -rf /root/* /tmp/* $(gem env gemdir)/cache \


### PR DESCRIPTION
In runtime `bigdecimal` is needed by some plugins like helpdesk. Installing `ruby-dev` and `build-base` apk packages would ship this dependency too. To avoid holding many dev dependencies in the image we add the gem at build time.

Resolves #123 