### PR TITLE
Add bigdecimal bundle as a dependency of the helpdesk plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add bigdecimal bundle as a dependency of the `helpdesk` plugin
 
 ## [v5.0.5-3] - 2024-01-17
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,7 +132,8 @@ RUN set -eux -o pipefail \
  && bundle config set --local without 'development test' \
  && bundle install \
  && gem install puma \
- && gem install bigdecimal \
+ && gem install bigdecimal -v 3.1.5 \
+ && bundle add bigdecimal --version=3.1.5 \
  # cleanup
  && gem cleanup all \
  && rm -rf /root/* /tmp/* $(gem env gemdir)/cache \


### PR DESCRIPTION
Another PR for issue #123 
PR #124 only solved the problem for bigdecimal 3.1.5, but it re-appeared with the release of bigdecimal 3.1.6. This PR should fix the problem in general.