### PR TITLE
#185 fix inter dogu https communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#185] fix inter dogu https communication with self sigend certificates
 
 ## [v6.1.1-4] - 2026-02-18
 ### Security

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -5,6 +5,9 @@ Im Folgenden finden Sie die Release Notes für das Redmine-Dogu.
 Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https://docs.cloudogu.com/de/docs/dogus/redmine/CHANGELOG/).
 
 ## [Unreleased]
+### Fixed
+- [#185] HTTPS-Kommunikation von Redmine zu einem anderen Dogu mit
+  selbstsignierten Zertifikaten behoben
 
 ## [v6.1.1-4] - 2026-02-18
 ### Security

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -5,6 +5,8 @@ Below you will find the release notes for the Redmine Dogu.
 Technical details on a release can be found in the corresponding [Changelog](https://docs.cloudogu.com/en/docs/dogus/redmine/CHANGELOG/).
 
 ## [Unreleased]
+### Fixed
+- [#185] Fixed inter dogu https communication with self sigend certificates
 
 ## [v6.1.1-4] - 2026-02-18
 ### Security

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -176,9 +176,12 @@ function runMain() {
   doguctl state "ready"
   doguctl config --rm "local_state"
 
+  # install ca certificates, to allow communication with other dogus via https
+  create-ca-certificates.sh
+
   # Start redmine
   echo "Starting redmine..."
-  exec su - redmine -c "RAILS_MASTER_KEY=\$(cat ${WORKDIR}/config/credentials/production.key) AUTO_MANAGED=true RAILS_RELATIVE_URL_ROOT=${RAILS_RELATIVE_URL_ROOT} puma -e ${RAILS_ENV} -p 3000"
+  exec su - redmine -c "RAILS_MASTER_KEY=\$(cat ${WORKDIR}/config/credentials/production.key) AUTO_MANAGED=true RAILS_RELATIVE_URL_ROOT=${RAILS_RELATIVE_URL_ROOT} SSL_CERT_FILE=/etc/ssl/ca-certificates.crt puma -e ${RAILS_ENV} -p 3000"
 }
 
 # make the script only run when executed, not when sourced from bats tests)


### PR DESCRIPTION
Fix communication between dogus over https  by installing the ces ca with create-ca-certificates.sh and passing the location of the created ca store with the SSL_CERT_FILE environment variable to redmine.

Closes #185 